### PR TITLE
Fix little typo in documentation

### DIFF
--- a/src/composite/fontselect.js
+++ b/src/composite/fontselect.js
@@ -91,7 +91,7 @@ var FontSelect = Select.$extend({
     /**
      * The placeholder displayed if nothing is selected.
      *
-     * @property Placeholder
+     * @property placeholder
      * @type String
      * @default "Select a font..."
      */

--- a/src/composite/select.js
+++ b/src/composite/select.js
@@ -121,7 +121,7 @@ var Select = Widget.$extend({
     /**
      * The placeholder displayed if nothing is selected.
      *
-     * @property Placeholder
+     * @property placeholder
      * @type String
      * @default "Select..."
      */


### PR DESCRIPTION
Fix little typo in convention name of a property in documentation