### PR TITLE
Added stretchToParentHeight property to BoxLayout

### DIFF
--- a/less/base/layout/boxlayout.less
+++ b/less/base/layout/boxlayout.less
@@ -33,7 +33,6 @@
     display: -webkit-flex !important;
     display: flex !important;
     box-sizing: border-box;
-    height: 100%;
 }
 
 .photonui-boxlayout.photonui-layout-orientation-horizontal {

--- a/src/layout/boxlayout.js
+++ b/src/layout/boxlayout.js
@@ -67,7 +67,7 @@ var BoxLayout = Layout.$extend({
     // Constructor
     __init__: function (params) {
         this.$super(params);
-        this._updateProperties(["orientation"]);
+        this._updateProperties(["orientation", "stretchToParentSize"]);
     },
 
     //////////////////////////////////////////
@@ -189,6 +189,24 @@ var BoxLayout = Layout.$extend({
     },
 
     /**
+     * Whether to stretch the box to its parent size or not.
+     *
+     * @property stretchToParentSize
+     * @type Boolean
+     * @default true
+     */
+    _stretchToParentHeight: true,
+
+    getStretchToParentHeight: function () {
+        return this._stretchToParentHeight;
+    },
+
+    setStretchToParentHeight: function (stretch) {
+        this._stretchToParentHeight = stretch;
+        this._updateLayout();
+    },
+
+    /**
      * Html outer element of the widget (if any).
      *
      * @property html
@@ -225,6 +243,12 @@ var BoxLayout = Layout.$extend({
      */
     _updateLayout: function () {
         Helpers.cleanNode(this.__html.outerbox);
+
+        if (this._stretchToParentHeight) {
+            this.__html.outerbox.style.height = "100%";
+        } else {
+            this.__html.outerbox.style.height = "";
+        }
 
         var fragment = document.createDocumentFragment();
         var children = this.children;

--- a/src/layout/boxlayout.js
+++ b/src/layout/boxlayout.js
@@ -67,7 +67,7 @@ var BoxLayout = Layout.$extend({
     // Constructor
     __init__: function (params) {
         this.$super(params);
-        this._updateProperties(["orientation", "stretchToParentSize"]);
+        this._updateProperties(["orientation", "stretchToParentHeight"]);
     },
 
     //////////////////////////////////////////
@@ -189,9 +189,9 @@ var BoxLayout = Layout.$extend({
     },
 
     /**
-     * Whether to stretch the box to its parent size or not.
+     * Whether to stretch the box to its parent height or not.
      *
-     * @property stretchToParentSize
+     * @property stretchToParentHeight
      * @type Boolean
      * @default true
      */
@@ -203,7 +203,12 @@ var BoxLayout = Layout.$extend({
 
     setStretchToParentHeight: function (stretch) {
         this._stretchToParentHeight = stretch;
-        this._updateLayout();
+
+        if (this._stretchToParentHeight) {
+            this.__html.outerbox.style.height = "100%";
+        } else {
+            this.__html.outerbox.style.height = "";
+        }
     },
 
     /**
@@ -243,12 +248,6 @@ var BoxLayout = Layout.$extend({
      */
     _updateLayout: function () {
         Helpers.cleanNode(this.__html.outerbox);
-
-        if (this._stretchToParentHeight) {
-            this.__html.outerbox.style.height = "100%";
-        } else {
-            this.__html.outerbox.style.height = "";
-        }
 
         var fragment = document.createDocumentFragment();
         var children = this.children;


### PR DESCRIPTION
This allows BoxLayout not to be streched anymore (previous behavior).
Old behaviour is default one.